### PR TITLE
Fix Supabase env vars for auth screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ View your app in AI Studio: https://ai.studio/apps/drive/1jdC6VV5wE5Xbjqsm1l5FP2
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create an `.env.local` file (or update the existing one) in the project root with the following values:
+
+   ```bash
+   GEMINI_API_KEY="<your Gemini API key>"
+   VITE_SUPABASE_URL="<your Supabase project URL>"
+   VITE_SUPABASE_ANON_KEY="<your Supabase anon key>"
+   ```
+
+   > **Note:** Vite only exposes environment variables prefixed with `VITE_`. Without these variables the authentication client cannot initialize and the sign-in screen will not render.
+
 3. Run the app:
    `npm run dev`

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -3,15 +3,15 @@ import type { User } from '../types';
 import { UserRole } from '../types';
 
 // =================================================================================
-// The client now reads from the .env.local file.
+// The client now reads from the .env.local file (Vite environment).
 // You MUST create a .env.local file in the root of your project
-// and add your Supabase credentials there.
+// and add your Supabase credentials there using the Vite `VITE_` prefix.
 //
-// REACT_APP_SUPABASE_URL="YOUR_SUPABASE_URL"
-// REACT_APP_SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"
+// VITE_SUPABASE_URL="YOUR_SUPABASE_URL"
+// VITE_SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"
 // =================================================================================
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
 
 if (!supabaseUrl || !supabaseAnonKey || supabaseUrl === 'YOUR_SUPABASE_URL') {


### PR DESCRIPTION
## Summary
- update the Supabase client to read credentials from Vite `VITE_` environment variables so the auth screen can render
- document the required environment variables in the README to highlight why the screen was blank

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d762b434e883289fb49796749033fd