### PR TITLE
Support legacy Supabase env names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ View your app in AI Studio: https://ai.studio/apps/drive/1jdC6VV5wE5Xbjqsm1l5FP2
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create an `.env.local` file (or update the existing one) in the project root with the following values:
+
+   ```bash
+   GEMINI_API_KEY="<your Gemini API key>"
+   VITE_SUPABASE_URL="<your Supabase project URL>"
+   VITE_SUPABASE_ANON_KEY="<your Supabase anon key>"
+   ```
+
+   > **Note:** Vite only exposes environment variables prefixed with `VITE_`. If you previously configured `REACT_APP_SUPABASE_*` values, you can keep them—both naming conventions are now supported. Without one of these variable sets the authentication client cannot initialize and the sign-in screen will not render.
+
 3. Run the app:
    `npm run dev`

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -3,33 +3,50 @@ import type { User } from '../types';
 import { UserRole } from '../types';
 
 // =================================================================================
-// The client now reads from the .env.local file.
+// The client now reads from the .env.local file (Vite environment).
 // You MUST create a .env.local file in the root of your project
-// and add your Supabase credentials there.
+// and add your Supabase credentials there using the Vite `VITE_` prefix.
 //
-// REACT_APP_SUPABASE_URL="YOUR_SUPABASE_URL"
-// REACT_APP_SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"
+// VITE_SUPABASE_URL="YOUR_SUPABASE_URL"
+// VITE_SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"
 // =================================================================================
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+const viteEnv = typeof import.meta !== 'undefined' ? (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {} : {};
+
+const supabaseUrl = (
+    viteEnv?.VITE_SUPABASE_URL ??
+    viteEnv?.REACT_APP_SUPABASE_URL ??
+    process.env.VITE_SUPABASE_URL ??
+    process.env.REACT_APP_SUPABASE_URL
+) as string | undefined;
+
+const supabaseAnonKey = (
+    viteEnv?.VITE_SUPABASE_ANON_KEY ??
+    viteEnv?.REACT_APP_SUPABASE_ANON_KEY ??
+    process.env.VITE_SUPABASE_ANON_KEY ??
+    process.env.REACT_APP_SUPABASE_ANON_KEY
+) as string | undefined;
 
 
-if (!supabaseUrl || !supabaseAnonKey || supabaseUrl === 'YOUR_SUPABASE_URL') {
-    const errorDiv = document.createElement('div');
-    errorDiv.style.position = 'fixed';
-    errorDiv.style.top = '10px';
-    errorDiv.style.left = '10px';
-    errorDiv.style.padding = '10px';
-    errorDiv.style.background = 'red';
-    errorDiv.style.color = 'white';
-    errorDiv.style.zIndex = '1000';
-    errorDiv.style.fontSize = '14px';
-    errorDiv.style.borderRadius = '5px';
-    errorDiv.innerHTML = '<b>CRITICAL ERROR:</b> Supabase client is not configured. Please open the <code>.env.local</code> file in your project and add your Supabase URL and Anon Key.';
-    document.body.prepend(errorDiv);
-    
+const missingSupabaseConfig = !supabaseUrl || !supabaseAnonKey || supabaseUrl === 'YOUR_SUPABASE_URL';
+
+if (missingSupabaseConfig) {
+    if (typeof document !== 'undefined') {
+        const errorDiv = document.createElement('div');
+        errorDiv.style.position = 'fixed';
+        errorDiv.style.top = '10px';
+        errorDiv.style.left = '10px';
+        errorDiv.style.padding = '10px';
+        errorDiv.style.background = 'red';
+        errorDiv.style.color = 'white';
+        errorDiv.style.zIndex = '1000';
+        errorDiv.style.fontSize = '14px';
+        errorDiv.style.borderRadius = '5px';
+        errorDiv.innerHTML = '<b>CRITICAL ERROR:</b> Supabase client is not configured. Please open the <code>.env.local</code> file in your project and add your Supabase URL and Anon Key.';
+        document.body.prepend(errorDiv);
+    }
+
     // Throw an error to stop execution
-    throw new Error("Supabase credentials are not configured in .env.local file.");
+    throw new Error('Supabase credentials are not configured in .env.local file.');
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- update the Supabase client to read either `VITE_` or legacy `REACT_APP_` environment variables so authentication still boots for existing setups
- guard the in-browser error helper so it only runs when `document` is available
- clarify the README to mention both supported environment variable prefixes

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d762b434e883289fb49796749033fd