### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, createContext, useContext } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import type { User } from './types';
 import { UserRole } from './types';
-import { supabase, getProfile } from './lib/supabaseClient';
+import { supabase, getProfile, isSupabaseConfigured } from './lib/supabaseClient';
 import type { Session } from '@supabase/supabase-js';
 
 import Sidebar from './components/Sidebar';
@@ -44,6 +44,11 @@ const App: React.FC = () => {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
+        if (!isSupabaseConfigured) {
+            setLoading(false);
+            return;
+        }
+
         const fetchSession = async () => {
             const { data: { session } } = await supabase.auth.getSession();
             setSession(session);
@@ -72,6 +77,9 @@ const App: React.FC = () => {
     }, []);
 
     const handleLogout = async () => {
+        if (!isSupabaseConfigured) {
+            return;
+        }
         await supabase.auth.signOut();
     };
 
@@ -83,6 +91,21 @@ const App: React.FC = () => {
         return (
             <div className="flex h-screen w-screen items-center justify-center bg-usace-bg">
                 <Loader className="h-8 w-8 animate-spin text-usace-red" />
+            </div>
+        );
+    }
+
+    if (!isSupabaseConfigured) {
+        return (
+            <div className="flex min-h-screen flex-col items-center justify-center bg-usace-bg p-6 text-center text-white">
+                <h1 className="mb-4 text-2xl font-semibold">Supabase configuration missing</h1>
+                <p className="max-w-lg text-gray-300">
+                    To use the USACE PAO KPI Tracker you need to create a <code>.env.local</code> file in the project root and
+                    provide the <code>VITE_SUPABASE_URL</code> and <code>VITE_SUPABASE_ANON_KEY</code> values from your Supabase project.
+                </p>
+                <p className="mt-4 max-w-lg text-gray-400">
+                    After saving the file, restart the development server and reload this page.
+                </p>
             </div>
         );
     }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -13,26 +13,22 @@ import { UserRole } from '../types';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
+export const isSupabaseConfigured = Boolean(
+    supabaseUrl &&
+    supabaseAnonKey &&
+    supabaseUrl !== 'YOUR_SUPABASE_URL'
+);
 
-if (!supabaseUrl || !supabaseAnonKey || supabaseUrl === 'YOUR_SUPABASE_URL') {
-    const errorDiv = document.createElement('div');
-    errorDiv.style.position = 'fixed';
-    errorDiv.style.top = '10px';
-    errorDiv.style.left = '10px';
-    errorDiv.style.padding = '10px';
-    errorDiv.style.background = 'red';
-    errorDiv.style.color = 'white';
-    errorDiv.style.zIndex = '1000';
-    errorDiv.style.fontSize = '14px';
-    errorDiv.style.borderRadius = '5px';
-    errorDiv.innerHTML = '<b>CRITICAL ERROR:</b> Supabase client is not configured. Please open the <code>.env.local</code> file in your project and add your Supabase URL and Anon Key.';
-    document.body.prepend(errorDiv);
-    
-    // Throw an error to stop execution
-    throw new Error("Supabase credentials are not configured in .env.local file.");
+if (!isSupabaseConfigured) {
+    console.error(
+        'Supabase client is not configured. Please create a .env.local file and add VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
+    );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = isSupabaseConfigured
+    ? createClient(supabaseUrl!, supabaseAnonKey!)
+    // We guard all runtime usage of supabase when the configuration is missing.
+    : null as unknown as ReturnType<typeof createClient>;
 
 /**
  * Fetches the public profile for a given user ID.


### PR DESCRIPTION
## Summary
- avoid throwing a runtime error when Supabase credentials are missing
- surface a friendly configuration message in the app when Supabase is not set up
- guard Supabase usage until credentials are provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7659b89388328857024344e7636da