### PR TITLE
Clarify Supabase credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,15 @@ View your app in AI Studio: https://ai.studio/apps/drive/1jdC6VV5wE5Xbjqsm1l5FP2
 
    > **Note:** Vite only exposes environment variables prefixed with `VITE_`. Without these variables the authentication client cannot initialize and the sign-in screen will not render.
 
+   ### Why the Supabase URL & anon key live in `.env.local`
+
+   Supabase's anon key is intentionally designed to be public. It is the same credential that ships in Supabase's own quick-start examples and it only grants the permissions defined in your project's `auth` policies. This means:
+
+   * Keeping the anon key in `.env.local` (or setting it as an environment variable in your hosting provider's dashboard) does **not** leak elevated privileges.
+   * Secrets that must remain private&mdash;such as the service-role key or third-party API tokens&mdash;should be stored with `supabase secrets set ...` and accessed from [Edge Functions](https://supabase.com/docs/guides/functions) or other server-side code. These secrets are **not** available to the browser bundle.
+   * When deploying, configure `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in your hosting platform's environment-variable settings instead of committing them to version control. Vite injects the values at build time so they never need to appear in your source files.
+
+   In short, you still create the `.env.local` file for local development, but you rely on your deployment platform's environment-variable management for production builds while sensitive credentials remain in Supabase's managed secrets.
+
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- explain why the Supabase URL and anon key remain in the Vite environment
- document how to keep sensitive keys in Supabase secrets and use host-provided env vars

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89bcf50148328a403f13b87d92016