### PR TITLE
Show auth screen when Supabase is not configured

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -95,23 +95,24 @@ const App: React.FC = () => {
         );
     }
 
-    if (!isSupabaseConfigured) {
-        return (
-            <div className="flex min-h-screen flex-col items-center justify-center bg-usace-bg p-6 text-center text-white">
-                <h1 className="mb-4 text-2xl font-semibold">Supabase configuration missing</h1>
-                <p className="max-w-lg text-gray-300">
-                    To use the USACE PAO KPI Tracker you need to create a <code>.env.local</code> file in the project root and
-                    provide the <code>VITE_SUPABASE_URL</code> and <code>VITE_SUPABASE_ANON_KEY</code> values from your Supabase project.
-                </p>
-                <p className="mt-4 max-w-lg text-gray-400">
-                    After saving the file, restart the development server and reload this page.
-                </p>
-            </div>
-        );
-    }
-
     if (!session || !user) {
-        return <AuthScreen />;
+        return (
+            <AuthScreen
+                disabled={!isSupabaseConfigured}
+                notice={!isSupabaseConfigured ? (
+                    <>
+                        <p className="font-semibold">Supabase configuration missing</p>
+                        <p className="mt-1 text-xs text-gray-300">
+                            Create a <code>.env.local</code> file in the project root with <code>VITE_SUPABASE_URL</code> and
+                            <code>VITE_SUPABASE_ANON_KEY</code> to enable authentication.
+                        </p>
+                        <p className="mt-2 text-xs text-gray-400">
+                            After saving the file, restart the development server and reload this page.
+                        </p>
+                    </>
+                ) : undefined}
+            />
+        );
     }
 
     return (

--- a/screens/AuthScreen.tsx
+++ b/screens/AuthScreen.tsx
@@ -2,22 +2,37 @@ import React, { useState } from 'react';
 import Button from '../components/Button';
 import { LogIn, Loader } from 'lucide-react';
 import Logo from '../components/Logo';
-import { supabase } from '../lib/supabaseClient';
+import { supabase, isSupabaseConfigured } from '../lib/supabaseClient';
 
-const AuthInput: React.FC<{id: string, type: string, placeholder: string, value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void}> = ({id, type, placeholder, value, onChange}) => (
+interface AuthInputProps {
+    id: string;
+    type: string;
+    placeholder: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    disabled?: boolean;
+}
+
+const AuthInput: React.FC<AuthInputProps> = ({ id, type, placeholder, value, onChange, disabled = false }) => (
     <input
         id={id}
         name={id}
         type={type}
         required
-        className="w-full px-3 py-2 bg-usace-border border border-usace-border rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-usace-red"
+        className="w-full px-3 py-2 bg-usace-border border border-usace-border rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-usace-red disabled:opacity-60"
         placeholder={placeholder}
         value={value}
         onChange={onChange}
+        disabled={disabled}
     />
 );
 
-const AuthScreen: React.FC = () => {
+interface AuthScreenProps {
+    disabled?: boolean;
+    notice?: React.ReactNode;
+}
+
+const AuthScreen: React.FC<AuthScreenProps> = ({ disabled = false, notice }) => {
     const [isSignIn, setIsSignIn] = useState(true);
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -28,6 +43,11 @@ const AuthScreen: React.FC = () => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        if (disabled || !isSupabaseConfigured) {
+            setError('Authentication is currently unavailable. Please configure Supabase to enable sign in and sign up.');
+            return;
+        }
+
         setLoading(true);
         setError(null);
         setMessage(null);
@@ -67,8 +87,13 @@ const AuthScreen: React.FC = () => {
                 </div>
                 <h1 className="text-2xl font-bold text-center text-white mb-2">USACE PAO KPI Tracker</h1>
                 <p className="text-center text-gray-400 mb-8">Please sign in to continue</p>
-                
+
                 <div className="bg-usace-card p-8 rounded-lg shadow-lg border border-usace-border">
+                    {notice && (
+                        <div className="mb-4 rounded border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-300">
+                            {notice}
+                        </div>
+                    )}
                     <div className="flex border-b border-usace-border mb-6">
                         <button onClick={() => { setIsSignIn(true); setError(null); setMessage(null); }} className={`w-1/2 py-3 text-sm font-medium ${isSignIn ? 'text-usace-red border-b-2 border-usace-red' : 'text-gray-400'}`}>
                             Sign In
@@ -83,18 +108,18 @@ const AuthScreen: React.FC = () => {
 
                     <form onSubmit={handleSubmit} className="space-y-6">
                         {!isSignIn && (
-                           <AuthInput id="fullName" type="text" placeholder="Full Name" value={fullName} onChange={(e) => setFullName(e.target.value)} />
+                           <AuthInput id="fullName" type="text" placeholder="Full Name" value={fullName} onChange={(e) => setFullName(e.target.value)} disabled={disabled} />
                         )}
-                        <AuthInput id="email" type="email" placeholder="Email Address" value={email} onChange={(e) => setEmail(e.target.value)} />
-                        <AuthInput id="password" type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
-                        
+                        <AuthInput id="email" type="email" placeholder="Email Address" value={email} onChange={(e) => setEmail(e.target.value)} disabled={disabled} />
+                        <AuthInput id="password" type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} disabled={disabled} />
+
                         {isSignIn && (
                             <div className="flex items-center justify-between">
-                                <a href="#" className="text-sm text-usace-red hover:underline">Forgot password?</a>
+                                <a href="#" className={`text-sm ${disabled ? 'text-gray-500' : 'text-usace-red hover:underline'}`}>Forgot password?</a>
                             </div>
                         )}
 
-                        <Button type="submit" className="w-full" Icon={loading ? Loader : LogIn} disabled={loading}>
+                        <Button type="submit" className="w-full" Icon={loading ? Loader : LogIn} disabled={loading || disabled}>
                             {loading ? (isSignIn ? 'Signing In...' : 'Creating Account...') : (isSignIn ? 'Sign In' : 'Create Account')}
                         </Button>
                     </form>


### PR DESCRIPTION
## Summary
- allow the authentication screen to render even when Supabase credentials are missing
- disable form controls and surface a notice explaining how to configure Supabase before signing in

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d89fbcaa4883288b5ea35e586d03cd