### PR TITLE
Fix logo SVG namespace to restore sign-in rendering

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -8,7 +8,7 @@ const Logo: React.FC<LogoProps> = ({ className }) => {
     return (
         <svg
             viewBox="0 0 512 384"
-            xmlns="https://commons.wikimedia.org/wiki/File:US-ArmyCorpsOfEngineers-Logo.svg#/media/File:United_States_Army_Corps_of_Engineers_logo.svg"
+            xmlns="http://www.w3.org/2000/svg"
             role="img"
             aria-label="USACE Castle logo"
             className={className}


### PR DESCRIPTION
## Summary
- correct the USACE logo SVG namespace so the sign-in screen renders without runtime errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9850095948328be75df708caa1437