### PR TITLE
Ensure auth preview bypasses Supabase session fetch

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -84,6 +84,14 @@ const App: React.FC = () => {
     }, []);
 
     useEffect(() => {
+        if (forceAuthPreview) {
+            setSession(null);
+            setUser(null);
+            setAuthError(null);
+            setLoading(false);
+            return;
+        }
+
         if (!isSupabaseConfigured) {
             setLoading(false);
             return;
@@ -145,7 +153,7 @@ const App: React.FC = () => {
         return () => {
             subscription.unsubscribe();
         };
-    }, []);
+    }, [forceAuthPreview]);
 
     const handleLogout = async () => {
         if (!isSupabaseConfigured) {


### PR DESCRIPTION
## Summary
- short-circuit the Supabase session effect when the auth-preview flag is active so the login screen renders immediately
- keep session state cleared and stop listening for auth updates while in preview mode to avoid unnecessary Supabase calls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c1451ce48328a5f0d29d15ac32c8