### PR TITLE
Improve Supabase auth diagnostics for misconfigured URLs

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,13 @@ import React, { useState, useEffect, createContext, useContext } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import type { User } from './types';
 import { UserRole } from './types';
-import { supabase, getProfile, isSupabaseConfigured, supabaseInitError } from './lib/supabaseClient';
+import {
+    supabase,
+    getProfile,
+    isSupabaseConfigured,
+    supabaseInitError,
+    supabaseProjectHostname,
+} from './lib/supabaseClient';
 import type { Session } from '@supabase/supabase-js';
 
 import Sidebar from './components/Sidebar';
@@ -102,6 +108,9 @@ const App: React.FC = () => {
     const [authError, setAuthError] = useState<string | null>(null);
     const [forceAuthPreview, setForceAuthPreview] = useState(false);
 
+    const supabaseEndpointLabel = supabaseProjectHostname ?? 'the authentication service';
+    const connectionErrorMessage = `We could not connect to ${supabaseEndpointLabel}. Please verify your Supabase configuration and try again.`;
+
     useEffect(() => {
         const resolveAuthPreviewFlag = () => {
             try {
@@ -159,7 +168,7 @@ const App: React.FC = () => {
                 const { data: { session }, error } = await supabase.auth.getSession();
                 if (error) {
                     console.error('Error fetching session:', error.message);
-                    setAuthError('We could not connect to the authentication service. Please refresh the page or try again later.');
+                    setAuthError(connectionErrorMessage);
                 } else {
                     setAuthError(null);
                 }
@@ -183,7 +192,7 @@ const App: React.FC = () => {
                 console.error('Unexpected error fetching session:', error);
                 setSession(null);
                 setUser(null);
-                setAuthError('We could not connect to the authentication service. Please refresh the page or try again later.');
+                setAuthError(connectionErrorMessage);
             } finally {
                 setLoading(false);
             }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ View your app in AI Studio: https://ai.studio/apps/drive/1jdC6VV5wE5Xbjqsm1l5FP2
 
    If you simply need to review the authentication UI without wiring up Supabase yet, append `?auth-preview=1` to the preview URL (or `/#/?auth-preview=1` when using hash routing). This toggles an interactive demo mode that keeps form submissions disabled until real Supabase credentials are configured.
 
+   > **Troubleshooting:** If the sign-in or sign-up forms report `Failed to fetch`, open your browser's network tab to confirm which host the request is targeting. Ensure `VITE_SUPABASE_URL` exactly matches your Supabase project's URL (for example, `https://<project-ref>.supabase.co`) or your local Supabase CLI URL (`http://127.0.0.1:54321`). DNS errors such as `ERR_NAME_NOT_RESOLVED` typically mean the hostname is misspelled or the project has been deleted.
+
    ### Why the Supabase URL & anon key live in `.env.local`
 
    Supabase's anon key is intentionally designed to be public. It is the same credential that ships in Supabase's own quick-start examples and it only grants the permissions defined in your project's `auth` policies. This means:


### PR DESCRIPTION
## Summary
- normalize the Supabase URL, capture its hostname, and expose it for downstream messaging
- show a clearer network failure error when sign-in or sign-up requests cannot reach Supabase
- update the README with troubleshooting guidance for common `Failed to fetch` issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df3d5796ec8328b0dbb3bb889a21a2