### PR TITLE
Exclude Supabase functions from TypeScript checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,8 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "exclude": [
+    "supabase/functions"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude the Supabase Edge function sources from the main tsconfig so the Vite app no longer reports Deno-specific type errors during compilation

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dff9e391d08328af79c671a5b10f22