### PR TITLE
Enable auth preview when Supabase configuration is missing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -106,7 +106,7 @@ const App: React.FC = () => {
     const [user, setUser] = useState<User | null>(null);
     const [loading, setLoading] = useState(true);
     const [authError, setAuthError] = useState<string | null>(null);
-    const [forceAuthPreview, setForceAuthPreview] = useState(false);
+    const [forceAuthPreview, setForceAuthPreview] = useState(!isSupabaseConfigured);
 
     const supabaseEndpointLabel = supabaseProjectHostname ?? 'the authentication service';
     const connectionErrorMessage = `We could not connect to ${supabaseEndpointLabel}. Please verify your Supabase configuration and try again.`;
@@ -136,7 +136,7 @@ const App: React.FC = () => {
         };
 
         const updateAuthPreview = () => {
-            setForceAuthPreview(resolveAuthPreviewFlag());
+            setForceAuthPreview(resolveAuthPreviewFlag() || !isSupabaseConfigured);
         };
 
         updateAuthPreview();
@@ -147,7 +147,7 @@ const App: React.FC = () => {
             window.removeEventListener('hashchange', updateAuthPreview);
             window.removeEventListener('popstate', updateAuthPreview);
         };
-    }, []);
+    }, [isSupabaseConfigured]);
 
     useEffect(() => {
         if (forceAuthPreview) {


### PR DESCRIPTION
## Summary
- default the application into authentication preview mode whenever Supabase credentials are not configured
- keep the preview enabled unless Supabase becomes configured or the auth-preview flag is present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e09651b4fc8328a30cf6791eba95c2