### PR TITLE
Fix duplicate auth preview state causing blank auth screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -108,7 +108,6 @@ const App: React.FC = () => {
     const [loading, setLoading] = useState(!initialAuthPreview && isSupabaseConfigured);
     const [authError, setAuthError] = useState<string | null>(null);
     const [forceAuthPreview, setForceAuthPreview] = useState(initialAuthPreview);
-    const [forceAuthPreview, setForceAuthPreview] = useState(!isSupabaseConfigured);
 
     const supabaseEndpointLabel = supabaseProjectHostname ?? 'the authentication service';
     const connectionErrorMessage = `We could not connect to ${supabaseEndpointLabel}. Please verify your Supabase configuration and try again.`;


### PR DESCRIPTION
## Summary
- remove the duplicated `forceAuthPreview` state declaration that was preventing the auth screen from rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e10edb780c83289d871e73abe80388